### PR TITLE
Updated dependencies (fixes not building)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,19 +12,19 @@ keywords = ["axum", "arti", "onion", "tor"]
 categories = ["network-programming", "web-programming::http-server"]
 
 [dependencies]
-axum = "0.7.4"
+axum = "0.7.5"
 futures-util = "0.3.30"
-hyper = "1.1.0"
+hyper = "1.2.0"
 hyper-util = "0.1.3"
-pin-project-lite = "0.2.13"
-tokio = "1.36.0"
-tor-cell = "0.16.0"
-tor-hsservice = "0.7.0"
-tor-proto = { version = "0.16.0", features = ["hs-service", "tokio"] }
+pin-project-lite = "0.2.14"
+tokio = "1.37.0"
+tor-cell = "0.17.0"
+tor-hsservice = "0.17.0"
+tor-proto = { version = "0.17.0", features = ["hs-service", "tokio"] }
 tower = "0.4.13"
 tower-service = "0.3.2"
 tracing = "0.1.40"
 
 [dev-dependencies]
-tokio = { version = "1.36.0", features = ["macros", "rt-multi-thread"] }
-arti-client = { version = "0.14.0", features = ["tokio", "onion-service-service"]}
+tokio = { version = "1.37.0", features = ["macros", "rt-multi-thread"] }
+arti-client = { version = "0.17.0", features = ["tokio", "onion-service-service"]}


### PR DESCRIPTION
I tried building the project and it would not work due to outdated dependencies (specifically, due to `tor-circmgr 0.15`, requested by an outdated `tor-cell`, which doesn't build)
I updated all the dependencies and now it builds and works normally